### PR TITLE
Fix def-noargs-function wrong module reference

### DIFF
--- a/src/eye_boof/pixel_math.clj
+++ b/src/eye_boof/pixel_math.clj
@@ -1,6 +1,6 @@
 (ns eye-boof.pixel-math
   (:require
-   [eye-boof.image-statistics :refer [def-noargs-function]]
+   [eye-boof.utils :refer [def-noargs-function]]
    [eye-boof.core :as c])
   (:import
    [boofcv.alg.misc PixelMath]))


### PR DESCRIPTION
Refers to macro in image-statistics which is in utils
